### PR TITLE
[#3] Test::Mojo _test() method replaced with test()

### DIFF
--- a/lib/Test/Mojo/Trim.pm
+++ b/lib/Test/Mojo/Trim.pm
@@ -32,7 +32,7 @@ sub trimmed_content_is {
         $got = '<see error>';
     }
 
-    return $self->_test('is', $got, $value, $desc);
+    return $self->test('is', $got, $value, $desc);
 }
 
 sub squish {

--- a/lib/Test/Mojo/Trim.pm
+++ b/lib/Test/Mojo/Trim.pm
@@ -32,7 +32,12 @@ sub trimmed_content_is {
         $got = '<see error>';
     }
 
-    return $self->test('is', $got, $value, $desc);
+    my $method = $self->can('test');
+    if ( !$method ) {
+        $method = $self->can('_test');
+    }
+
+    return $self->$method('is', $got, $value, $desc);
 }
 
 sub squish {


### PR DESCRIPTION
This happened in commit 3723973fd5003b82d11c990a76d50adba4826758 (see https://github.com/mojolicious/mojo/commit/3723973fd5003b82d11c990a76d50adba4826758).